### PR TITLE
chore: improve model typing and docs

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,12 +1,13 @@
-import { Component, signal } from '@angular/core';
+import { Component, signal, Signal } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'app-root',
   imports: [RouterOutlet],
   templateUrl: './app.html',
-  styleUrl: './app.scss'
+  styleUrl: './app.scss',
 })
 export class App {
-  protected readonly title = signal('ng-skein');
+  /** Application title displayed in the header */
+  protected readonly title: Signal<string> = signal('ng-skein');
 }

--- a/src/app/core/model/doc-envelope.model.prompt.md
+++ b/src/app/core/model/doc-envelope.model.prompt.md
@@ -1,4 +1,4 @@
-# 📨 DocEnvelope<T> Model
+# 📨 DocEnvelope<TData> Model
 
 This model wraps arbitrary data (`T`) for storage in PouchDB. It standardizes document structure for all persisted objects in the system, ensuring they include the necessary `_id` and optional `_rev` fields for Couch-style replication and conflict resolution.
 
@@ -6,23 +6,23 @@ This model wraps arbitrary data (`T`) for storage in PouchDB. It standardizes do
 
 ## 📦 Purpose
 
-`DocEnvelope<T>` is a generic container used to store typed data in PouchDB. It adds revision control metadata required by the database, while keeping the wrapped domain object isolated inside the `data` field.
+`DocEnvelope<TData>` is a generic container used to store typed data in PouchDB. It adds revision control metadata required by the database, while keeping the wrapped domain object isolated inside the `data` field.
 
 This makes the envelope:
 
 - Compatible with PouchDB and CouchDB’s replication model
 - Easily versioned (`_rev`)
-- Type-safe and model-agnostic (`T`)
+- Type-safe and model-agnostic (`TData`)
 
 ---
 
 ## 🧱 Structure
 
 ```ts
-export interface DocEnvelope<T = any> {
-  _id: string;       // Required: Unique key, often namespaced
-  _rev?: string;     // Optional: Used for update/merge by PouchDB
-  data: T;           // Payload: Any domain object
+export interface DocEnvelope<TData = unknown> {
+  _id: string; // Required: Unique key, often namespaced
+  _rev?: string; // Optional: Used for update/merge by PouchDB
+  data: TData; // Payload: Any domain object
 }
 ```
 
@@ -62,7 +62,7 @@ const envelope: DocEnvelope<Picklist> = {
 
 ## 🧑‍💻 For GPT Use
 
-- Always wrap saved domain models in `DocEnvelope<T>`
-- Do not store raw `T` objects directly in PouchDB
+- Always wrap saved domain models in `DocEnvelope<TData>`
+- Do not store raw `TData` objects directly in PouchDB
 - For new documents, omit `_rev`
 - When updating, ensure `_rev` is preserved to avoid conflicts

--- a/src/app/core/model/doc-envelope.model.ts
+++ b/src/app/core/model/doc-envelope.model.ts
@@ -1,5 +1,11 @@
-export interface DocEnvelope<T = any> {
+/**
+ * Wraps a domain object with PouchDB metadata for storage.
+ */
+export interface DocEnvelope<TData = unknown> {
+  /** Required unique document identifier */
   _id: string;
+  /** Optional revision token for conflict resolution */
   _rev?: string;
-  data: T;
+  /** Domain data payload */
+  data: TData;
 }

--- a/src/app/core/model/event-scope.model.prompt.md
+++ b/src/app/core/model/event-scope.model.prompt.md
@@ -9,11 +9,14 @@ It provides a structured way to scope events and state in the workflow engine us
 ## 🧱 Structure
 
 ```ts
+/**
+ * Hierarchical namespace used to categorize persisted events.
+ */
 export interface EventScope {
-  domain: string;         // Primary domain (e.g., "picking")
-  subdomain?: string;     // Optional subdomain (e.g., "picklist")
-  context?: string;       // Optional unique instance (e.g., "PL1234")
-  subcontext?: string;    // Optional step or nested scope (e.g., "step1")
+  domain: string; // Primary domain (e.g., "picking")
+  subdomain?: string; // Optional subdomain (e.g., "picklist")
+  context?: string; // Optional unique instance (e.g., "PL1234")
+  subcontext?: string; // Optional step or nested scope (e.g., "step1")
 }
 ```
 
@@ -39,13 +42,13 @@ export interface EventScope {
 
 ```ts
 const scope: EventScope = {
-  domain: 'picking',
-  subdomain: 'picklist',
-  context: 'PL1234',
-  subcontext: 'step1'
+  domain: "picking",
+  subdomain: "picklist",
+  context: "PL1234",
+  subcontext: "step1",
 };
 
-const id = buildIdFromScope('events', scope);
+const id = buildIdFromScope("events", scope);
 // → "events:picking:picklist:PL1234:step1"
 ```
 

--- a/src/app/core/model/event-scope.model.ts
+++ b/src/app/core/model/event-scope.model.ts
@@ -1,6 +1,13 @@
+/**
+ * Hierarchical namespace used to categorize persisted events.
+ */
 export interface EventScope {
+  /** Primary domain (e.g., "picking") */
   domain: string;
+  /** Optional subdomain (e.g., "picklist") */
   subdomain?: string;
+  /** Optional unique instance (e.g., document ID) */
   context?: string;
+  /** Optional nested scope within the context */
   subcontext?: string;
 }


### PR DESCRIPTION
## Summary
- type App component title signal explicitly
- document DocEnvelope and EventScope models
- use safer default typing for DocEnvelope

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6895429d65348330a721c91524be12f2